### PR TITLE
Fix compiler error related to 'struct kstat'

### DIFF
--- a/include/linux/susfs.h
+++ b/include/linux/susfs.h
@@ -7,6 +7,7 @@
 #include <linux/hashtable.h>
 #include <linux/path.h>
 #include <linux/susfs_def.h>
+#include <linux/stat.h>
 #include <linux/statfs.h>
 
 #define SUSFS_VERSION "v2.1.0"


### PR DESCRIPTION
Induced header linux/stat.h so that there is a definition for 'struct kstat'. Otherwise this is implicitly declared below as a parameter in a declaration for 'susfs_generic_fillattr_spoofer' (previously called susfs_sus_ino_for_generic_fillattr'.

This causes a compiler problem with your driver at this file: https://github.com/sidex15/KernelSU-Next/blob/legacy-susfs-v2/kernel/supercall/dispatch.c

It complains that the included file susfs.h has an implicit declaration for 'struct kstat' and that this declaration will not be visible outside of the declaration for 'susfs_generic_fillattr_spoofer'