### PR TITLE
Change su domain from 'su' to 'ksu'

### DIFF
--- a/fs/susfs.c
+++ b/fs/susfs.c
@@ -1415,7 +1415,7 @@ static int susfs_sdcard_monitor_fn(void *data)
 		return -ENOMEM;
 	}
 
-	setup_selinux("u:r:su:s0", cred);
+	setup_selinux("u:r:ksu:s0", cred);
 	commit_creds(cred);
 
 	if (!susfs_is_current_ksu_domain()) {


### PR DESCRIPTION
Tiniest of things and there will obviously be several larger official SUSFS things to adapt, but I spent ages trying to work out why the sdcard_monitor function was exiting as not su... Turns out KSU & SUSFS official (and your fork) have changed the su domain to 'ksu' and so that needs changed here to match and then it works fine without further changes; there probably are further changes/optimizations but this quickly restores it to working again!

I couldn't find many other instances of hardcoding a context like this in the other files, other than with AVC spoofing 'u:r:priv_app:s0:c512,c768' and so unless they suddenly feel the need to rename init, zygote or priv_app, I doubt it's likely to be a problem in future!

Feel free to close this without merging as I'm sure you don't need a one character commit, but just to make you aware 😊